### PR TITLE
Readd flags for linking statically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 x86 :
-	i686-w64-mingw32-clang++ fxc2.cpp -ofxc2.exe
+	i686-w64-mingw32-clang++ -static fxc2.cpp -ofxc2.exe
 x64 :
-	x86_64-w64-mingw32-clang++ fxc2.cpp -ofxc2.exe
+	x86_64-w64-mingw32-clang++ -static fxc2.cpp -ofxc2.exe


### PR DESCRIPTION
Even if building with a mingw clang toolchain, the C++ standard library
may exist in dynamically linked form.

If the C++ standard library doesn't exist in dynamically linked form,
this makes no difference.