### PR TITLE
Don't free an error string before actually printing it

### DIFF
--- a/fxc2.cpp
+++ b/fxc2.cpp
@@ -264,9 +264,8 @@ int main(int argc, char* argv[])
      LPSTR messageBuffer = nullptr;
      size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                                  NULL, hr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
-     std::string message(messageBuffer, size);
-     LocalFree(messageBuffer);
      printf("Windows Error Message: %s\n", messageBuffer);
+     LocalFree(messageBuffer);
    }
 
    if (output)


### PR DESCRIPTION
Also skip making an unused std::string copy of it.